### PR TITLE
Added front-end validation, improved form usability

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -12,4 +12,77 @@ $(document).ready(function () {
     }, 1000);
   });
 
+  $.fn.validate = function() {
+    var previous_invalid_inputs = [];
+
+    var validateInput = function() {
+      var success = true, types = $(this).data('validate').split(/[ ,]+/), value = $(this).val();
+      for (i = types.length-1; i >= 0; i--) {
+        switch (types[i]) {
+          case 'presence':
+            if (!value || $.trim(value).length < 1) {
+              notify(this, "can't be blank");
+              success = false;
+            }
+          break;
+          case 'email':
+            if (value) {
+              var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+              if (!re.test(value)) {
+                notify(this, "is invalid");
+                success = false;
+              }
+            }
+          break;
+        }
+      }
+      if (success) {
+        $(this).parent().removeClass('field_with_errors').find('.error').fadeOut(200, function() {
+          $(this).remove();
+        });
+      }
+      return success;
+    };
+
+    var validateAll = function() {
+      var success = true, invalid_inputs = [], first_input;
+      $(this).find('[data-validate]').each(function(i) {
+        if (!validateInput.call(this)) {
+          success = false;
+          invalid_inputs.push(i);
+          if (!first_input || $(this).is(':focus')) {
+            first_input = this;
+          }
+        }
+      });
+      if (invalid_inputs.length > 0 && $(invalid_inputs).not(previous_invalid_inputs).length == 0 && $(previous_invalid_inputs).not(invalid_inputs).length == 0) {
+        $(this).find('[data-validate]').each(function() {
+          $(this).parent().find('.error').fadeOut(50).fadeIn(100);
+        });
+      }
+      if (first_input) {
+        $(first_input).focus();
+      }
+      previous_invalid_inputs = invalid_inputs;
+      return success;
+    };
+
+    var notify = function(input, message) {
+      var $element = $(input).parent().find('.error');
+      if ($element.length < 1)  {
+        $element = $('<span class="error"></span>').hide().insertAfter(input);
+      }
+      $element.text(message);
+      $element.fadeIn(100);
+      $element.parent().addClass('field_with_errors');
+    };
+
+    $(this).on('submit', validateAll);
+    $(this).find('[data-validate]').each(function() {
+      $(this).on('blur', validateInput);
+    });
+  };
+
+  $('[data-validate=form]').validate();
+
 });

--- a/app/assets/javascripts/participants.js
+++ b/app/assets/javascripts/participants.js
@@ -1,33 +1,25 @@
 $(document).ready(function () {
 
   $('[data-school-picker]').autocomplete({
-      // appendTo: 'div.school_selection',
-      source: function( request, response ) {
-        $.ajax({
-          url: '/apply/schools',
-          dataType: 'json',
-          data: {
-            name: request.term
-          },
-          success: function( data ) {
-            response( data );
-          }
-        });
-      },
-      // hides helper messages
-      messages: {
-        noResults: '',
-        results: function() {}
-      },
-      minLength: 3,
-      select: function( event, ui ) {
-
-      },
-      open: function() {
-      },
-      close: function() {
-
-      }
-    });
+    source: function( request, response ) {
+      $.ajax({
+        url: '/apply/schools',
+        dataType: 'json',
+        data: {
+          name: request.term
+        },
+        success: function( data ) {
+          response( data );
+        }
+      });
+    },
+    // hides helper messages
+    messages: {
+      noResults: '',
+      results: function() {}
+    },
+    minLength: 3,
+    delay: 100
+  });
 
 });

--- a/app/assets/stylesheets/_forms.css.sass
+++ b/app/assets/stylesheets/_forms.css.sass
@@ -88,9 +88,10 @@ select
   color: $blue
   list-style: none
   padding: 0
-  .ui-menu-item
+  .ui-menu-item a
     padding: 2px 5px
-    &:hover
+    display: block
+    &:hover, &.ui-state-focus
       background: $orange-light
       color: $white
 

--- a/app/views/participants/_form.html.haml
+++ b/app/views/participants/_form.html.haml
@@ -18,4 +18,4 @@
     = f.input :interest, as: :select, collection: Participant::POSSIBLE_INTERESTS.map { |interest| [interest.titleize, interest] }, include_blank: "(select one...)"
 
     %div{class:'center'}
-      = f.button :submit, class:"button", value:'Apply'
+      = f.button :submit, class:"button", value: ( @participant.new_record? ? 'Apply' : 'Save' )

--- a/app/views/participants/_form.html.haml
+++ b/app/views/participants/_form.html.haml
@@ -1,21 +1,21 @@
 %div{class:'form-container'}
-  = simple_form_for @participant do |f|
+  = simple_form_for @participant, html: { "data-validate" => "form" } do |f|
 
     .form-inputs
-    = f.input :first_name, placeholder: "Joe"
-    = f.input :last_name, placeholder: "Smith"
-    = f.input :email, placeholder: "joe@example.com"
-    = f.input :birthday, start_year: Date.today.year - 18, end_year: Date.today.year - 90, order: [:month, :day, :year]
+    = f.input :first_name, placeholder: "Joe", input_html: { "data-validate" => "presence" }
+    = f.input :last_name, placeholder: "Smith", input_html: { "data-validate" => "presence" }
+    = f.input :email, placeholder: "joe@example.com", input_html: { "data-validate" => "presence email" }
+    = f.input :birthday, start_year: Date.today.year - 18, end_year: Date.today.year - 90, order: [:month, :day, :year], input_html: { "data-validate" => "presence" }
 
-    = f.input :school_id, as: :school_selection, placeholder: "My University"
-    = f.input :year, as: :select, collection: Participant::POSSIBLE_YEARS, include_blank: "(select one...)"
+    = f.input :school_id, as: :school_selection, placeholder: "My University", input_html: { "data-validate" => "presence" }
+    = f.input :year, as: :select, collection: Participant::POSSIBLE_YEARS, include_blank: "(select one...)", input_html: { "data-validate" => "presence" }
 
-    = f.input :city, placeholder: "Anytown"
-    = f.input :state, placeholder: "New York"
+    = f.input :city, placeholder: "Anytown", input_html: { "data-validate" => "presence" }
+    = f.input :state, placeholder: "New York", input_html: { "data-validate" => "presence" }
 
-    = f.input :experience, as: :select, collection: Participant::POSSIBLE_EXPERIENCES, include_blank: "(select one...)", label: "Hackathon Experience"
+    = f.input :experience, as: :select, collection: Participant::POSSIBLE_EXPERIENCES, include_blank: "(select one...)", label: "Hackathon Experience", input_html: { "data-validate" => "presence" }
 
-    = f.input :interest, as: :select, collection: Participant::POSSIBLE_INTERESTS.map { |interest| [interest.titleize, interest] }, include_blank: "(select one...)"
+    = f.input :interest, as: :select, collection: Participant::POSSIBLE_INTERESTS.map { |interest| [interest.titleize, interest] }, include_blank: "(select one...)", input_html: { "data-validate" => "presence" }
 
     %div{class:'center'}
       = f.button :submit, class:"button", value: ( @participant.new_record? ? 'Apply' : 'Save' )


### PR DESCRIPTION
Generates errors as if it were being validated by the server. Includes two basic validations, presence and email.

Add validation to a form by adding `data-validtion="form"` to the `<form>` tag, and `data-validation="type"` to any input, where `type` is a type of validation (presence or email), or multiple types separated by a space or comma.

If the user tries to submit the form while there are errors, the first invalid input will focus if no others are. If they try repeatedly without making corrections, the error messages will flash.