### PR TITLE
Fixed Typo

### DIFF
--- a/app/views/questionnaires/_form.html.haml
+++ b/app/views/questionnaires/_form.html.haml
@@ -30,7 +30,7 @@
         = f.input :resume, as: :deletable_attachment, hint: "Must be < 2MB", input_html: { "data-validate" => "file-max-size file-content-type", "data-validate-file-max-size" => "2097152", "data-validate-file-content-type" => "application/pdf" }, label: "Resume (PDF)"
 
         = f.input :portfolio_url, label: "Portfolio Link", placeholder:"http://mywebsite.com"
-        = f.input :vcs_url, label: "GitHub/BitBucket", placeholder:"http://github.com/coderit"
+        = f.input :vcs_url, label: "GitHub/BitBucket", placeholder:"https://github.com/coderit"
 
       %div{class:'center'}
         %button.button{ type: "button", "data-wizard" => "previous" } Previous


### PR DESCRIPTION
GitHub URLs cannot be http, GitHub forces https use. This fixes the
filler text for a user's GitHub/BitBucket repository