### PR TITLE
Use email signature seperator convention

### DIFF
--- a/app/views/mailer/application_confirmation_email.text.erb
+++ b/app/views/mailer/application_confirmation_email.text.erb
@@ -20,7 +20,7 @@ Dietary & Medical Notes: <%= @questionnaire.dietary_medical_notes || "None" %>
 Portfolio Link: <%= @questionnaire.portfolio_url? ? @questionnaire.portfolio_url : 'Not provided' %>
 GitHub/BitBucket Link: <%= @questionnaire.vcs_url? ? @questionnaire.vcs_url : 'Not provided' %>
 
---
+-- 
 codeRIT | BrickHack
 http://coderit.org
 http://brickhack.io


### PR DESCRIPTION
The [`"-- "` convention](https://en.wikipedia.org/wiki/Signature_block#cite_note-1) allows some mail clients to detect the signature and render it appropriately.