### PR TITLE
Corrected css & js resource on error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
   <head>
@@ -16,30 +15,30 @@
     <meta content='BrickHack' name='twitter:title'>
     <meta content='/assets/brickhack_logo.png' name='twitter:image'>
     <meta content='BrickHack: RIT’s premiere collegiate hackathon. April 18th ignites a weekend devoted to 400 designers and coders sinking 24 hours into building and creating.' name='twitter:description'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
-    <link href='http://localhost:3000/assets/favicon/favicon.ico' rel='shortcut icon'>
-    <link href='http://localhost:3000/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
+    <link href='/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
+    <link href='/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
+    <link href='/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
+    <link href='/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
+    <link href='/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
+    <link href='/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
+    <link href='/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
+    <link href='/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
+    <link href='/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
+    <link href='/assets/favicon/favicon.ico' rel='shortcut icon'>
+    <link href='/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
+    <link href='/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
+    <link href='/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
+    <link href='/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
+    <link href='/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
     <meta content='#f9f6f3' name='msapplication-TileColor'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
+    <meta content='/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
+    <meta content='/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
+    <meta content='/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
+    <meta content='/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
+    <meta content='/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
     <link href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Roboto:400,900,300,100,500,700' rel='stylesheet' type='text/css'>
-    <link href="/assets/application.css?body=1" media="all" rel="stylesheet" type="text/css" />
+    <link href="/assets/application.css" media="all" rel="stylesheet" type="text/css" />
     <meta content="authenticity_token" name="csrf-param" />
     <meta content="BhkM+GEppyJawLe0QufX6YgYju9l500v3aLKIWsWrEY=" name="csrf-token" />
   </head>
@@ -111,15 +110,6 @@
         </div>
       </div>
     </div>
-    <script src="/assets/jquery.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery_ujs.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.core.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.widget.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.position.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.menu.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.autocomplete.js?body=1" type="text/javascript"></script>
-    <script src="/assets/main.js?body=1" type="text/javascript"></script>
-    <script src="/assets/registrations.js?body=1" type="text/javascript"></script>
-    <script src="/assets/application.js?body=1" type="text/javascript"></script>
+    <script src="/assets/application.js" type="text/javascript"></script>
   </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
   <head>
@@ -16,30 +15,30 @@
     <meta content='BrickHack' name='twitter:title'>
     <meta content='/assets/brickhack_logo.png' name='twitter:image'>
     <meta content='BrickHack: RIT’s premiere collegiate hackathon. April 18th ignites a weekend devoted to 400 designers and coders sinking 24 hours into building and creating.' name='twitter:description'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
-    <link href='http://localhost:3000/assets/favicon/favicon.ico' rel='shortcut icon'>
-    <link href='http://localhost:3000/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
+    <link href='/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
+    <link href='/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
+    <link href='/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
+    <link href='/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
+    <link href='/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
+    <link href='/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
+    <link href='/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
+    <link href='/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
+    <link href='/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
+    <link href='/assets/favicon/favicon.ico' rel='shortcut icon'>
+    <link href='/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
+    <link href='/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
+    <link href='/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
+    <link href='/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
+    <link href='/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
     <meta content='#f9f6f3' name='msapplication-TileColor'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
+    <meta content='/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
+    <meta content='/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
+    <meta content='/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
+    <meta content='/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
+    <meta content='/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
     <link href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Roboto:400,900,300,100,500,700' rel='stylesheet' type='text/css'>
-    <link href="/assets/application.css?body=1" media="all" rel="stylesheet" type="text/css" />
+    <link href="/assets/application.css" media="all" rel="stylesheet" type="text/css" />
     <meta content="authenticity_token" name="csrf-param" />
     <meta content="BhkM+GEppyJawLe0QufX6YgYju9l500v3aLKIWsWrEY=" name="csrf-token" />
   </head>
@@ -111,15 +110,6 @@
         </div>
       </div>
     </div>
-    <script src="/assets/jquery.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery_ujs.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.core.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.widget.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.position.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.menu.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.autocomplete.js?body=1" type="text/javascript"></script>
-    <script src="/assets/main.js?body=1" type="text/javascript"></script>
-    <script src="/assets/registrations.js?body=1" type="text/javascript"></script>
-    <script src="/assets/application.js?body=1" type="text/javascript"></script>
-</body>
+    <script src="/assets/application.js" type="text/javascript"></script>
+  </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
   <head>
@@ -16,30 +15,30 @@
     <meta content='BrickHack' name='twitter:title'>
     <meta content='/assets/brickhack_logo.png' name='twitter:image'>
     <meta content='BrickHack: RIT’s premiere collegiate hackathon. April 18th ignites a weekend devoted to 400 designers and coders sinking 24 hours into building and creating.' name='twitter:description'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
-    <link href='http://localhost:3000/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
-    <link href='http://localhost:3000/assets/favicon/favicon.ico' rel='shortcut icon'>
-    <link href='http://localhost:3000/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
-    <link href='http://localhost:3000/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
+    <link href='/assets/favicon/apple-touch-icon-57x57.png' rel='apple-touch-icon' sizes='57x57'>
+    <link href='/assets/favicon/apple-touch-icon-114x114.png' rel='apple-touch-icon' sizes='114x114'>
+    <link href='/assets/favicon/apple-touch-icon-72x72.png' rel='apple-touch-icon' sizes='72x72'>
+    <link href='/assets/favicon/apple-touch-icon-144x144.png' rel='apple-touch-icon' sizes='144x144'>
+    <link href='/assets/favicon/apple-touch-icon-60x60.png' rel='apple-touch-icon' sizes='60x60'>
+    <link href='/assets/favicon/apple-touch-icon-120x120.png' rel='apple-touch-icon' sizes='120x120'>
+    <link href='/assets/favicon/apple-touch-icon-76x76.png' rel='apple-touch-icon' sizes='76x76'>
+    <link href='/assets/favicon/apple-touch-icon-152x152.png' rel='apple-touch-icon' sizes='152x152'>
+    <link href='/assets/favicon/apple-touch-icon-180x180.png' rel='apple-touch-icon' sizes='180x180'>
+    <link href='/assets/favicon/favicon.ico' rel='shortcut icon'>
+    <link href='/assets/favicon/favicon-192x192.png' rel='icon' sizes='192x192' type='image/png'>
+    <link href='/assets/favicon/favicon-160x160.png' rel='icon' sizes='160x160' type='image/png'>
+    <link href='/assets/favicon/favicon-96x96.png' rel='icon' sizes='96x96' type='image/png'>
+    <link href='/assets/favicon/favicon-16x16.png' rel='icon' sizes='16x16' type='image/png'>
+    <link href='/assets/favicon/favicon-32x32.png' rel='icon' sizes='32x32' type='image/png'>
     <meta content='#f9f6f3' name='msapplication-TileColor'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
-    <meta content='http://localhost:3000/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
+    <meta content='/assets/favicon/mstile-144x144.png' name='msapplication-TileImage'>
+    <meta content='/assets/favicon/mstile-70x70.png' name='msapplication-square70x70logo'>
+    <meta content='/assets/favicon/mstile-150x150.png' name='msapplication-square150x150logo'>
+    <meta content='/assets/favicon/mstile-310x310.png' name='msapplication-square310x310logo'>
+    <meta content='/assets/favicon/mstile-310x150.png' name='msapplication-wide310x150logo'>
     <link href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Roboto:400,900,300,100,500,700' rel='stylesheet' type='text/css'>
-    <link href="/assets/application.css?body=1" media="all" rel="stylesheet" type="text/css" />
+    <link href="/assets/application.css" media="all" rel="stylesheet" type="text/css" />
     <meta content="authenticity_token" name="csrf-param" />
     <meta content="BhkM+GEppyJawLe0QufX6YgYju9l500v3aLKIWsWrEY=" name="csrf-token" />
   </head>
@@ -111,15 +110,6 @@
         </div>
       </div>
     </div>
-    <script src="/assets/jquery.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery_ujs.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.core.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.widget.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.position.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.menu.js?body=1" type="text/javascript"></script>
-    <script src="/assets/jquery.ui.autocomplete.js?body=1" type="text/javascript"></script>
-    <script src="/assets/main.js?body=1" type="text/javascript"></script>
-    <script src="/assets/registrations.js?body=1" type="text/javascript"></script>
-    <script src="/assets/application.js?body=1" type="text/javascript"></script>
+    <script src="/assets/application.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
Caused numerous 404 errors in Rollbar, ontop of not working properly in the first place.

Changing to controller-based error pages would solve this unless there's a gem out there that automatically creates static html error pages when necessary