### PR TITLE
Removed routing errors from Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -34,6 +34,8 @@ Rollbar.configure do |config|
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
+  config.exception_level_filters.merge!('ActionController::RoutingError' => 'ignore')
+
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)
   # config.use_async = true


### PR DESCRIPTION
Safe to say if it doesn't exist, it doesn't exist. There are better ways to check for 404 errors that exist in our app if we want to target them.