### PR TITLE
Added caching for dashboard map data

### DIFF
--- a/app/helpers/manage/dashboard_helper.rb
+++ b/app/helpers/manage/dashboard_helper.rb
@@ -1,3 +1,7 @@
 module Manage::DashboardHelper
-
+  def cache_key_for_questionnaires
+    count          = Questionnaire.count
+    max_updated_at = Questionnaire.maximum(:updated_at).try(:utc).try(:to_s, :number)
+    "questionnaires/all-#{count}-#{max_updated_at}"
+  end
 end

--- a/app/views/manage/dashboard/map_data.tsv.erb
+++ b/app/views/manage/dashboard/map_data.tsv.erb
@@ -1,3 +1,4 @@
+<% cache(cache_key_for_questionnaires) do %>
 <%= "id\tapps" %>
 <%
 counties = {}
@@ -44,3 +45,4 @@ counties.each do |county, value|
   output += "#{county}\t#{value}\n"
 end %>
 <%= output %>
+<% end %>


### PR DESCRIPTION
Currently, the application map on the dashboard takes ~1.2 seconds to load, and is loaded on every visit. The data generation only needs to happen when there has been a new/deleted/modified questionnaire.