### PR TITLE
Switch from /apply/:id to /apply

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,10 @@ class ApplicationController < ActionController::Base
     elsif current_user.admin?
       manage_root_path
     elsif current_user.questionnaire === nil
-      new_questionnaire_path
+      new_questionnaires_path
     else
       @questionnaire = current_user.questionnaire
-      @questionnaire.can_rsvp? ? rsvp_path : questionnaire_path(@questionnaire)
+      @questionnaire.can_rsvp? ? rsvp_path : questionnaires_path
     end
   end
 end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -86,13 +86,13 @@ class RsvpsController < ApplicationController
 
   def check_user_has_questionnaire
     if current_user.questionnaire.nil?
-      redirect_to new_questionnaire_path
+      redirect_to new_questionnaires_path
     end
   end
 
   def require_accepted_questionnaire
     unless @questionnaire.can_rsvp? || @questionnaire.checked_in?
-      redirect_to new_questionnaire_path
+      redirect_to new_questionnaires_path
     end
   end
 

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -10,7 +10,7 @@
         - if current_user.admin?
           = btn_link_to "Manage", manage_root_path
         - else
-          = btn_link_to "Review", new_questionnaire_path
+          = btn_link_to "Review", new_questionnaires_path
       - if current_user.admin?
         %div
           = btn_link_to "My Account", edit_user_registration_path

--- a/app/views/mailer/application_confirmation_email.html.erb
+++ b/app/views/mailer/application_confirmation_email.html.erb
@@ -1,7 +1,7 @@
 <h2 style="margin: 0px 0px 10px;">Thanks for applying to BrickHack!</h2>
 <span class="orange-block" style="background: #F98728;display: block;height: 8px;margin-bottom: 35px;width: 200px;"></span>
 <p style="margin: 0 0 8px;">We've successfully received your application to BrickHack 2015. Below is a copy of your information.</p>
-<p style="margin: 0 0 8px;">If necessary, you may update your application at <a href="<%= edit_questionnaire_url(@questionnaire, host: "brickhack.io") %>" style="color: #F98728;"> <%= edit_questionnaire_url(@questionnaire, host: "brickhack.io") %></a></p>
+<p style="margin: 0 0 8px;">If necessary, you may update your application at <a href="<%= edit_questionnaires_url(host: "brickhack.io") %>" style="color: #F98728;"> <%= edit_questionnaires_url(host: "brickhack.io") %></a></p>
 <h4 style="margin: 0px 0px 10px;">You will be notified of your acceptance status some time before April 18th.</h4>
 <ul style="list-style: none;padding: 0;">
   <li style="margin:5px 0px;">Name: <%= @questionnaire.full_name %></li>

--- a/app/views/questionnaires/_form.html.haml
+++ b/app/views/questionnaires/_form.html.haml
@@ -1,5 +1,5 @@
 %div{class:'form-container wizard'}
-  = simple_form_for @questionnaire, html: { "data-validate" => "form" } do |f|
+  = simple_form_for @questionnaire, url: url_for(controller: "questionnaires", action: "update"), html: { "data-validate" => "form" } do |f|
 
     #disclaimer
       - unless @questionnaire.can_rsvp?

--- a/app/views/questionnaires/edit.html.haml
+++ b/app/views/questionnaires/edit.html.haml
@@ -4,4 +4,4 @@
 
 		= render 'form'
 
-		%p{class:"cancel_btn_wrap"}= link_to 'Cancel', @questionnaire
+		%p{class:"cancel_btn_wrap"}= link_to 'Cancel', questionnaires_path

--- a/app/views/questionnaires/show.html.haml
+++ b/app/views/questionnaires/show.html.haml
@@ -62,5 +62,5 @@
       = @questionnaire.vcs_url? ? link_to(@questionnaire.vcs_url, @questionnaire.vcs_url, target: '_blank') : 'Not provided'
 
     %p
-      = btn_link_to 'Edit Application &raquo;'.html_safe, edit_questionnaire_path(@questionnaire)
+      = btn_link_to 'Edit Application &raquo;'.html_safe, edit_questionnaires_path
       = btn_link_to 'Edit Account &raquo;'.html_safe, edit_user_registration_path

--- a/app/views/rsvps/show.html.haml
+++ b/app/views/rsvps/show.html.haml
@@ -50,5 +50,5 @@
         = f.input :riding_bus, as: :hidden, value: false
 
       .center
-        = btn_link_to "Edit Application", edit_questionnaire_path(@questionnaire)
+        = btn_link_to "Edit Application", edit_questionnaires_path
         = f.button :submit, value: "Update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ BrickhackIo::Application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  resources :questionnaires, path: "apply" do
+  resource :questionnaires, path: "apply" do
     get :schools, on: :collection
   end
 

--- a/test/functional/questionnaires_controller_test.rb
+++ b/test/functional/questionnaires_controller_test.rb
@@ -13,51 +13,26 @@ class QuestionnairesControllerTest < ActionController::TestCase
   end
 
   context "while not authenticated" do
-    should "redirect to sign up page on questionnaire#index" do
-      get :index
-      assert_redirected_to new_user_session_path
-    end
-
     should "redirect to sign up page on questionnaire#new" do
       get :new
       assert_redirected_to new_user_session_path
     end
 
     should "redirect to sign up page on questionnaire#edit" do
-      get :edit, id: @questionnaire
+      get :edit
       assert_redirected_to new_user_session_path
     end
 
     should "redirect to sign up page on questionnaire#update" do
-      put :update, id: @questionnaire, questionnaire: { city: "different" }
+      put :update, questionnaire: { city: "different" }
       assert_redirected_to new_user_session_path
     end
 
     should "redirect to sign up page on questionnaire#destroy" do
       assert_difference('Questionnaire.count', 0) do
-        delete :destroy, id: @questionnaire
+        delete :destroy
       end
       assert_redirected_to new_user_session_path
-    end
-
-    context "accessing a non-owned questionnaire" do
-      should "not allow #show" do
-        get :show, id: 0
-        assert_response :redirect
-        assert_redirected_to new_user_session_path
-      end
-
-      should "not allow #edit" do
-        get :edit, id: 0
-        assert_response :redirect
-        assert_redirected_to new_user_session_path
-      end
-
-      should "not not allow #update" do
-        put :update, id: 3, questionnaire: { first_name: "Foo" }
-        assert_response :redirect
-        assert_redirected_to new_user_session_path
-      end
     end
   end
 
@@ -78,7 +53,7 @@ class QuestionnairesControllerTest < ActionController::TestCase
         post :create, questionnaire: { city: @questionnaire.city, experience: @questionnaire.experience, first_name: @questionnaire.first_name, interest: @questionnaire.interest, last_name: @questionnaire.last_name, phone: @questionnaire.phone, state: @questionnaire.state, year: @questionnaire.year, birthday: @questionnaire.birthday, shirt_size: @questionnaire.shirt_size, school_id: @school.id, agreement_accepted: "1" }
       end
 
-      assert_redirected_to questionnaire_path(assigns(:questionnaire))
+      assert_redirected_to questionnaires_path
     end
 
     should "not allow multiple questionnaires" do
@@ -87,7 +62,7 @@ class QuestionnairesControllerTest < ActionController::TestCase
         post :create, questionnaire: { city: @questionnaire.city, experience: @questionnaire.experience, first_name: @questionnaire.first_name, interest: @questionnaire.interest, last_name: @questionnaire.last_name, phone: @questionnaire.phone, state: @questionnaire.state, year: @questionnaire.year, birthday: @questionnaire.birthday, shirt_size: @questionnaire.shirt_size, school_id: @school.id, agreement_accepted: "1" }
       end
 
-      assert_redirected_to questionnaire_path(assigns(:questionnaire))
+      assert_redirected_to questionnaires_path
     end
 
     context "with an invalid questionnaire" do
@@ -103,14 +78,14 @@ class QuestionnairesControllerTest < ActionController::TestCase
       context "on create" do
         should "save existing school name" do
           post :create, questionnaire: { city: @questionnaire.city, experience: @questionnaire.experience, first_name: @questionnaire.first_name, interest: @questionnaire.interest, last_name: @questionnaire.last_name, phone: @questionnaire.phone, state: @questionnaire.state, year: @questionnaire.year, birthday: @questionnaire.birthday, shirt_size: @questionnaire.shirt_size, school_name: @school.name, agreement_accepted: "1" }
-          assert_redirected_to questionnaire_path(assigns(:questionnaire))
+          assert_redirected_to questionnaires_path
           assert_equal 1, School.all.count
           assert_equal "late_waitlist", assigns(:questionnaire).acc_status, "should automatically waitlist"
         end
 
         should "create a new school when unknown" do
           post :create, questionnaire: { city: @questionnaire.city, experience: @questionnaire.experience, first_name: @questionnaire.first_name, interest: @questionnaire.interest, last_name: @questionnaire.last_name, phone: @questionnaire.phone, state: @questionnaire.state, year: @questionnaire.year, birthday: @questionnaire.birthday, shirt_size: @questionnaire.shirt_size, school_name: "New School", agreement_accepted: "1" }
-          assert_redirected_to questionnaire_path(assigns(:questionnaire))
+          assert_redirected_to questionnaires_path
           assert_equal 2, School.all.count
         end
 
@@ -129,37 +104,31 @@ class QuestionnairesControllerTest < ActionController::TestCase
       sign_in @questionnaire.user
     end
 
-    should "index should redirect to new" do
-      get :index
-      assert_response :redirect
-      assert_redirected_to new_questionnaire_path
-    end
-
     should "show questionnaire" do
-      get :show, id: @questionnaire
+      get :show
       assert_response :success
     end
 
     should "get edit" do
-      get :edit, id: @questionnaire
+      get :edit
       assert_response :success
     end
 
     should "get edit with questionnaire resume" do
       @questionnaire.resume = sample_file("sample_pdf.pdf")
       @questionnaire.save
-      get :edit, id: @questionnaire
+      get :edit
       assert_response :success
     end
 
     should "update questionnaire" do
-      put :update, id: @questionnaire, questionnaire: { first_name: "Foo" }
-      assert_redirected_to questionnaire_path(assigns(:questionnaire))
+      put :update, questionnaire: { first_name: "Foo" }
+      assert_redirected_to questionnaires_path
     end
 
     should "destroy questionnaire" do
       assert_difference('Questionnaire.count', -1) do
-        delete :destroy, id: @questionnaire
+        delete :destroy
       end
 
       assert_redirected_to questionnaires_path
@@ -168,35 +137,8 @@ class QuestionnairesControllerTest < ActionController::TestCase
     context "with invalid questionnaire params" do
       should "not allow updates" do
         saved_first_name = @questionnaire.first_name
-        put :update, id: @questionnaire, questionnaire: { first_name: "" }
+        put :update, questionnaire: { first_name: "" }
         assert_equal saved_first_name, @questionnaire.reload.first_name
-      end
-    end
-
-    context "accessing a non-owned questionnaire" do
-      should "not allow #show" do
-        get :show, id: 0
-        assert_response :redirect
-        assert_redirected_to questionnaire_path(@questionnaire)
-      end
-
-      should "not allow #edit" do
-        get :edit, id: 0
-        assert_response :redirect
-        assert_redirected_to questionnaire_path(@questionnaire)
-      end
-
-      should "not not allow #update" do
-        put :update, id: 3, questionnaire: { first_name: "Foo" }
-        assert_response :redirect
-        assert_redirected_to questionnaire_path(@questionnaire)
-      end
-
-      should "redirect to #new if a questionnaire has not been submitted" do
-        @questionnaire.delete
-        get :show, id: 0
-        assert_response :redirect
-        assert_redirected_to new_questionnaire_path
       end
     end
 
@@ -204,21 +146,21 @@ class QuestionnairesControllerTest < ActionController::TestCase
       should "redirect to existing questionnaire" do
         get :new
         assert_response :redirect
-        assert_redirected_to questionnaire_path(@questionnaire)
+        assert_redirected_to questionnaires_path
       end
     end
 
     context "#school_name" do
       context "on update" do
         should "save existing school name" do
-          put :update, id: @questionnaire, questionnaire: { school_name: @school.name }
-          assert_redirected_to questionnaire_path(assigns(:questionnaire))
+          put :update, questionnaire: { school_name: @school.name }
+          assert_redirected_to questionnaires_path
           assert_equal 1, School.all.count
         end
 
         should "create a new school when unknown" do
-          put :update, id: @questionnaire, questionnaire: { school_name: "New School" }
-          assert_redirected_to questionnaire_path(assigns(:questionnaire))
+          put :update, questionnaire: { school_name: "New School" }
+          assert_redirected_to questionnaires_path
           assert_equal 2, School.all.count
         end
       end

--- a/test/functional/rsvps_controller_test.rb
+++ b/test/functional/rsvps_controller_test.rb
@@ -42,22 +42,22 @@ class RsvpsControllerTest < ActionController::TestCase
 
     should "redirect to root page on rsvp#index" do
       get :show
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#accept" do
       get :accept
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#deny" do
       get :deny
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#update" do
       put :update
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
   end
 
@@ -70,22 +70,22 @@ class RsvpsControllerTest < ActionController::TestCase
 
     should "redirect to root page on rsvp#index" do
       get :show
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#accept" do
       get :accept
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#deny" do
       get :deny
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
 
     should "redirect to root page on rsvp#update" do
       put :update
-      assert_redirected_to new_questionnaire_path
+      assert_redirected_to new_questionnaires_path
     end
   end
 

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -5,7 +5,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     user = login(FactoryGirl.create(:user))
     admin = login(FactoryGirl.create(:admin))
 
-    user.assert_redirected_to new_questionnaire_path
+    user.assert_redirected_to new_questionnaires_path
     admin.assert_redirected_to manage_root_path
 
     user.browse_questionnaire
@@ -22,14 +22,14 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
   should "redirect to completed application after login" do
     questionnaire = FactoryGirl.create(:questionnaire)
     applied_user = login(questionnaire.user)
-    applied_user.assert_redirected_to questionnaire_path(questionnaire)
+    applied_user.assert_redirected_to questionnaires_path
   end
 
   private
 
     module CustomDsl
       def browse_questionnaire
-        get new_questionnaire_path
+        get new_questionnaires_path
         assert_response :success
         assert assigns(:questionnaire)
       end


### PR DESCRIPTION
Non-issue for this season as almost all applications are completed and links would possibly break, but the application pages shouldn't need an ID when the logged in user would only ever be viewing their own application.

The fix is very simple- switch from `resources :questionnaires` to `resource :questionnaires` in `routes.rb` and update questionnaire lookup logic in the public questionnaires controller. See the RSVP route & controller for example.