### PR TITLE
Manage fixes

### DIFF
--- a/app/controllers/manage/dashboard_controller.rb
+++ b/app/controllers/manage/dashboard_controller.rb
@@ -27,7 +27,7 @@ class Manage::DashboardController < Manage::ApplicationController
   def user_distribution_data
     totalStatsData = {}
     total_count = Questionnaire.count
-    rit_count = Questionnaire.where("school_id = \"2304\" OR school_id = \"5535\"").count
+    rit_count = Questionnaire.where("school_id = \"2304\"").count
     totalStatsData["Non-Applied Users"] = User.count - total_count
     totalStatsData["Non-RIT Applications"] = total_count - rit_count
     totalStatsData["RIT Applications"] = rit_count
@@ -71,9 +71,9 @@ class Manage::DashboardController < Manage::ApplicationController
       when "Applications"
         data = Questionnaire.send("group_by_#{group_type}", :created_at, range: range).count
       when "RIT Applications"
-        data = Questionnaire.where("school_id = \"2304\" OR school_id = \"5535\"").send("group_by_#{group_type}", :created_at, range: range).count
+        data = Questionnaire.where("school_id = \"2304\"").send("group_by_#{group_type}", :created_at, range: range).count
       when "Non-RIT Applications"
-        data = Questionnaire.where("school_id != \"2304\" OR school_id != \"5535\"").send("group_by_#{group_type}", :created_at, range: range).count
+        data = Questionnaire.where("school_id != \"2304\"").send("group_by_#{group_type}", :created_at, range: range).count
       when "Confirmations"
         data = Questionnaire.where(acc_status: "rsvp_confirmed").send("group_by_#{group_type}", :acc_status_date, range: range).count
       when "Denials"

--- a/app/controllers/manage/dashboard_controller.rb
+++ b/app/controllers/manage/dashboard_controller.rb
@@ -41,7 +41,7 @@ class Manage::DashboardController < Manage::ApplicationController
   end
 
   def schools_confirmed_data
-    schools = Questionnaire.joins(:school).group('schools.name').where("acc_status = 'rsvp_confirmed'").count
+    schools = Questionnaire.joins(:school).group('schools.name').where("acc_status = 'rsvp_confirmed'").order("schools.name ASC").count
     render :json => schools.sort_by { |name, count| count }.reverse
   end
 
@@ -55,7 +55,7 @@ class Manage::DashboardController < Manage::ApplicationController
       "accepted" => {},
       "rsvp_confirmed" => {}
     }
-    result = Questionnaire.joins(:school).group(:acc_status, "schools.name").where("schools.questionnaire_count >= 5").order("schools.questionnaire_count DESC").count
+    result = Questionnaire.joins(:school).group(:acc_status, "schools.name").where("schools.questionnaire_count >= 5").order("schools.questionnaire_count DESC").order("schools.name ASC").count
     result.each do |group, count|
       counted_schools[group[0]][group[1]] = count
     end

--- a/app/datatables/questionnaire_datatable.rb
+++ b/app/datatables/questionnaire_datatable.rb
@@ -21,6 +21,7 @@ class QuestionnaireDatatable < AjaxDatatablesRails::Base
       'Questionnaire.first_name',
       'Questionnaire.last_name',
       'User.admin',
+      'User.email',
       'School.name'
     ]
   end


### PR DESCRIPTION
RIT vs Non-RIT calculations were incorrect (was using an `OR` instead of `AND`) and we were supporting an alternate name of "Rochester Institute of Technology" which was removed.

You can also search applications by email now.