### PR TITLE
Email clean up & automated reminder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Documentation:
   Enabled: false
 
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false
 
@@ -8,4 +11,10 @@ Style/StringLiterals:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/RegexpLiteral:
   Enabled: false

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,6 +5,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, :event => :authentication # this will throw if @user is not activated
       session["devise.provider_data"] = request.env["omniauth.auth"]
       set_flash_message(:notice, :success, :kind => "My MLH") if is_navigational_format?
+      @user.queue_reminder_email
     else
       redirect_to new_user_registration_url
     end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,14 +1,14 @@
 class Mailer < ApplicationMailer
   include Roadie::Rails::Automatic
 
-  default from: '"codeRIT" <noreply@coderit.org>'
+  default from: '"BrickHack" <noreply@coderit.org>'
 
   def application_confirmation_email(questionnaire_id)
     @questionnaire = Questionnaire.find(questionnaire_id)
     return unless @questionnaire.present? && @questionnaire.user.present?
     mail(
       to: pretty_email(@questionnaire.full_name, @questionnaire.user.email),
-      subject: "[#{subject_base}] Application Received"
+      subject: "Application Received"
     )
   end
 
@@ -17,7 +17,7 @@ class Mailer < ApplicationMailer
     return unless @questionnaire.present? && @questionnaire.user.present?
     mail(
       to: pretty_email(@questionnaire.full_name, @questionnaire.user.email),
-      subject: "[#{subject_base}] RSVP Confirmation"
+      subject: "RSVP Confirmation"
     )
   end
 
@@ -26,7 +26,7 @@ class Mailer < ApplicationMailer
     return unless @questionnaire.present? && @questionnaire.user.present?
     mail(
       to: pretty_email(@questionnaire.full_name, @questionnaire.user.email),
-      subject: "[#{subject_base}] You've been accepted!"
+      subject: "You've been accepted!"
     )
   end
 
@@ -35,7 +35,7 @@ class Mailer < ApplicationMailer
     return unless @questionnaire.present? && @questionnaire.user.present?
     mail(
       to: pretty_email(@questionnaire.full_name, @questionnaire.user.email),
-      subject: "[#{subject_base}] Your application status"
+      subject: "Your application status"
     )
   end
 
@@ -45,15 +45,11 @@ class Mailer < ApplicationMailer
     return if @user.blank? || @message.blank?
     mail(
       to: pretty_email(@user.full_name, @user.email),
-      subject: "[#{subject_base}] #{@message.subject}"
+      subject: @message.subject
     )
   end
 
   private
-
-  def subject_base
-    "BrickHack"
-  end
 
   def pretty_email(name, email)
     return email if name.blank?

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -49,6 +49,15 @@ class Mailer < ApplicationMailer
     )
   end
 
+  def incomplete_reminder_email(user_id)
+    @user = User.find(user_id)
+    return if @user.blank? || @user.questionnaire || Time.now.to_date > LAST_DAY_TO_APPLY
+    mail(
+      to: @user.email,
+      subject: "Incomplete Application"
+    )
+  end
+
   private
 
   def pretty_email(name, email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,12 @@ class User < ApplicationRecord
     devise_mailer.send(notification, self, *args).deliver_later
   end
 
+  def queue_reminder_email
+    return if reminder_sent_at
+    Mailer.delay_for(4.days).incomplete_reminder_email(id)
+    update_attribute(:reminder_sent_at, Time.now)
+  end
+
   def email=(value)
     super value.try(:downcase)
   end

--- a/app/views/mailer/incomplete_reminder_email.html.erb
+++ b/app/views/mailer/incomplete_reminder_email.html.erb
@@ -1,0 +1,6 @@
+<h2>Finish Your Application</h2>
+<p>You're almost there! You completed the My MLH part of the application, but didn't finish the additional BrickHack-specific questions.</p>
+<p><strong>Your application will not be considered until it is completed.</strong></p>
+<p>Not to worry! Just head on back to the website, <a href="https://brickhack.io/apply">brickhack.io/apply</a>, sign in with your existing My MLH account (if necessary), and complete the application.</p>
+<p><a href="https://brickhack.io/apply" class="button">Finish Application »</a></p>
+<p>Happy hacking!<br> - The BrickHack Team</p>

--- a/app/views/manage/messages/_form.html.haml
+++ b/app/views/manage/messages/_form.html.haml
@@ -3,7 +3,7 @@
 
   .form-inputs
     = f.input :name
-    = f.input :subject, hint: "[BrickHack] Will be added before the subject when sent."
+    = f.input :subject, hint: "All emails are from \"BrickHack\""
     = f.input :template, as: :select, collection: Message::POSSIBLE_TEMPLATES.map { |x| [x.titleize, x] }, include_blank: false
     = f.input :recipients, as: :select, collection: Message::POSSIBLE_RECIPIENTS.invert, input_html: { class: "selectize", multiple: true }
     = f.input :body, hint: "codeRIT & BrickHack info will be appended to the email body"

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,2 +1,3 @@
 REGISTRATION_IS_OPEN = false
 EVENT_IS_OVER = true
+LAST_DAY_TO_APPLY = Date.new(2017, 2, 11)

--- a/db/migrate/20161206084722_add_reminder_sent_at_to_users.rb
+++ b/db/migrate/20161206084722_add_reminder_sent_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddReminderSentAtToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :reminder_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206073921) do
+ActiveRecord::Schema.define(version: 20161206084722) do
 
   create_table "bus_lists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20161206073921) do
     t.boolean  "admin_limited_access",   default: false
     t.string   "provider"
     t.string   "uid"
+    t.datetime "reminder_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["provider"], name: "index_users_on_provider", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/test/controllers/mailer_test.rb
+++ b/test/controllers/mailer_test.rb
@@ -93,4 +93,18 @@ class MailerTest < ActionMailer::TestCase
     end
   end
 
+  context "upon scheduled incomplete reminder email" do
+    setup do
+      @user = create(:user, email: "test@example.com")
+    end
+
+    should "deliver reminder email" do
+      email = Mailer.incomplete_reminder_email(@user.id).deliver_now
+
+      assert_equal ["test@example.com"],     email.to
+      assert_equal "Incomplete Application", email.subject
+      assert_match /brickhack.io\/apply/,    email.encoded
+    end
+  end
+
 end

--- a/test/controllers/mailer_test.rb
+++ b/test/controllers/mailer_test.rb
@@ -19,11 +19,11 @@ class MailerTest < ActionMailer::TestCase
     should "deliver email to questionnaire" do
       email = Mailer.application_confirmation_email(@questionnaire.id).deliver_now
 
-      assert_equal [@questionnaire.email],                email.to
-      assert_equal "[BrickHack] Application Received",  email.subject
+      assert_equal [@questionnaire.email],  email.to
+      assert_equal "Application Received",  email.subject
 
-      assert_match "Joe Smith",                         email.encoded
-      assert_match "joe.smith@example.com",             email.encoded
+      assert_match "Joe Smith",             email.encoded
+      assert_match "joe.smith@example.com", email.encoded
     end
   end
 
@@ -37,10 +37,10 @@ class MailerTest < ActionMailer::TestCase
     should "deliver email to questionnaire" do
       email = Mailer.rsvp_confirmation_email(@questionnaire.id).deliver_now
 
-      assert_equal [@questionnaire.email],              email.to
-      assert_equal "[BrickHack] RSVP Confirmation",     email.subject
+      assert_equal [@questionnaire.email], email.to
+      assert_equal "RSVP Confirmation",    email.subject
 
-      assert_match "You are confirmed",                 email.encoded
+      assert_match "You are confirmed",    email.encoded
     end
   end
 
@@ -54,10 +54,10 @@ class MailerTest < ActionMailer::TestCase
     should "deliver email to questionnaire" do
       email = Mailer.denied_email(@questionnaire.id).deliver_now
 
-      assert_equal [@questionnaire.email],              email.to
-      assert_equal "[BrickHack] Your application status", email.subject
+      assert_equal [@questionnaire.email],    email.to
+      assert_equal "Your application status", email.subject
 
-      assert_match "Dear ",                             email.encoded
+      assert_match "Dear ",                   email.encoded
     end
   end
 
@@ -71,10 +71,10 @@ class MailerTest < ActionMailer::TestCase
     should "deliver email to questionnaire" do
       email = Mailer.accepted_email(@questionnaire.id).deliver_now
 
-      assert_equal [@questionnaire.email],              email.to
-      assert_equal "[BrickHack] You've been accepted!", email.subject
+      assert_equal [@questionnaire.email],  email.to
+      assert_equal "You've been accepted!", email.subject
 
-      assert_match "Congratulations ",                  email.encoded
+      assert_match "Congratulations ",      email.encoded
     end
   end
 
@@ -87,9 +87,9 @@ class MailerTest < ActionMailer::TestCase
     should "deliver bulk messages" do
       email = Mailer.bulk_message_email(@message.id, @user.id).deliver_now
 
-      assert_equal ["test@example.com"],                email.to
-      assert_equal "[BrickHack] Example Subject",       email.subject
-      assert_match /Hello World/,                       email.encoded
+      assert_equal ["test@example.com"], email.to
+      assert_equal "Example Subject",    email.subject
+      assert_match /Hello World/,        email.encoded
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -50,4 +50,25 @@ class UserTest < ActiveSupport::TestCase
       assert_equal "", user.full_name
     end
   end
+
+  context "queue_reminder_email" do
+    before do
+      ActionMailer::Base.deliveries = []
+      Sidekiq::Extensions::DelayedMailer.jobs.clear
+    end
+
+    should "queue an email to be sent out" do
+      user = create(:user)
+      user.queue_reminder_email
+      assert_equal 1, Sidekiq::Extensions::DelayedMailer.jobs.size
+    end
+
+    should "only queue email once" do
+      user = create(:user)
+      user.queue_reminder_email
+      user.queue_reminder_email
+      user.queue_reminder_email
+      assert_equal 1, Sidekiq::Extensions::DelayedMailer.jobs.size
+    end
+  end
 end


### PR DESCRIPTION
* If a user hasn't completed their application, send them an automatic reminder 4 days later (#305)
* Remove `[BrickHack]` from email subjects & change the "from" to "BrickHack"