### PR TITLE
Mentor sign-up & reminder follow-up change

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   def queue_reminder_email
     return if self.reminder_sent_at
-    Mailer.delay_for(4.days).incomplete_reminder_email(id)
+    Mailer.delay_for(1.day).incomplete_reminder_email(id)
     update_attribute(:reminder_sent_at, Time.now)
   end
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -2,6 +2,9 @@
 
 = render "layouts/nav"
 
+- mentor_link = "https://goo.gl/forms/3rNdjlrS9u7gZX9p1".freeze
+- volunteer_link = "https://goo.gl/forms/7Z6dZmZxEOXXpBPA3".freeze
+
 .page.split-home#home
   .split-left
     = image_tag 'scroller.png'
@@ -32,8 +35,11 @@
         .button.button-outline SUBMISSIONS
     - else
       %br
-      = link_to "https://docs.google.com/forms/d/e/1FAIpQLSfvMIqzp_U_LxSOPP_bzYsAxgxJXLrh90f8VmnWO8P0p3l8iQ/viewform" do
+      = link_to volunteer_link do
         .button.button-outline VOLUNTEER
+      %br
+      = link_to mentor_link do
+        .button.button-outline MENTOR
 
 .grey-section.diagonal#about
   .home-content.about-gallery
@@ -111,7 +117,8 @@
 
       .column
         %h2 Who can participate in BrickHack?
-        %p Anyone who is currently enrolled as a student or has graduated within the last 12 months can attend! If you don't fit that description, you're welcome to attend as a mentor or volunteer!
+        %p
+          Anyone who is currently enrolled as a student or has graduated within the last 12 months can attend! If you don't fit that description, you're absolutely welcome to attend as a <a href="#{mentor_link}">mentor</a> or <a href="#{volunteer_link}">volunteer</a>.
         %p All attendees must be 18 years or older to attend. Proof of your age may be requested on the day of the event.
 
       .column


### PR DESCRIPTION
Add mentorship sign-up link & change delay of registration reminder email to 1 day instead of 4 days