### PR TITLE
Extend devise session time to 2 days

### DIFF
--- a/app/controllers/manage/dashboard_controller.rb
+++ b/app/controllers/manage/dashboard_controller.rb
@@ -94,7 +94,7 @@ class Manage::DashboardController < Manage::ApplicationController
       when "Denials"
         data = Questionnaire.where(acc_status: "rsvp_denied").send("group_by_#{group_type}", :acc_status_date, range: range).count
       when "Non-Applied Users"
-        data = User.without_questionnaire.send("group_by_#{group_type}", :acc_status_date, range: range).count
+        data = User.without_questionnaire.send("group_by_#{group_type}", "users.created_at", range: range).count
       end
       chart_data << { name: type, data: data }
     end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 2.days
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
Fixes #435

Allows for:
* Admins to stay signed in for longer
* Users that get a 1-day follow-up email to finish their account get 24 hours after the email to be already signed-in