### PR TITLE
Add support for duplicate school names

### DIFF
--- a/app/controllers/manage/schools_controller.rb
+++ b/app/controllers/manage/schools_controller.rb
@@ -60,6 +60,8 @@ class Manage::SchoolsController < Manage::ApplicationController
       q.update_attribute(:school_id, new_school.id)
     end
 
+    SchoolNameDuplicate.create(name: @school.name, school_id: new_school.id)
+
     @school.reload
 
     if @school.questionnaire_count < 1

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -1,6 +1,7 @@
 class Questionnaire < ApplicationRecord
   include ActiveModel::Dirty
 
+  before_validation :consolidate_school_names
   after_save :update_school_questionnaire_count
   after_destroy :update_school_questionnaire_count
 
@@ -131,6 +132,13 @@ class Questionnaire < ApplicationRecord
   end
 
   private
+
+  def consolidate_school_names
+    return if school.blank?
+    duplicate = SchoolNameDuplicate.find_by(name: school.name)
+    return if duplicate.blank?
+    self.school_id = duplicate.school_id
+  end
 
   def update_school_questionnaire_count
     if school_id_changed?

--- a/app/models/school_name_duplicate.rb
+++ b/app/models/school_name_duplicate.rb
@@ -1,0 +1,7 @@
+class SchoolNameDuplicate < ApplicationRecord
+  validates_uniqueness_of :name
+
+  strip_attributes
+
+  belongs_to :school
+end

--- a/app/views/manage/schools/merge.html.haml
+++ b/app/views/manage/schools/merge.html.haml
@@ -22,6 +22,11 @@
       .form-inputs
         = f.input :id, as: :school_selection, placeholder: "My University", input_html: { "data-validate" => "presence" }, label: "Merge Into:", value: ''
 
+      %p
+        This will rename all future applications with the
+        %strong= @school.full_name
+        school name to this new school.
+
       %div{class:'center'}
         = f.button :submit, value: 'Merge'
 

--- a/db/migrate/20170107210122_create_school_name_duplicates.rb
+++ b/db/migrate/20170107210122_create_school_name_duplicates.rb
@@ -1,0 +1,10 @@
+class CreateSchoolNameDuplicates < ActiveRecord::Migration[5.0]
+  def change
+    create_table :school_name_duplicates do |t|
+      t.string :name
+      t.belongs_to :school, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161212030010) do
+ActiveRecord::Schema.define(version: 20170107210122) do
 
   create_table "bus_lists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
@@ -84,6 +84,14 @@ ActiveRecord::Schema.define(version: 20161212030010) do
     t.index ["user_id"], name: "index_questionnaires_on_user_id", using: :btree
   end
 
+  create_table "school_name_duplicates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name"
+    t.integer  "school_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["school_id"], name: "index_school_name_duplicates_on_school_id", using: :btree
+  end
+
   create_table "schools", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
     t.string   "address"
@@ -129,4 +137,5 @@ ActiveRecord::Schema.define(version: 20161212030010) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
+  add_foreign_key "school_name_duplicates", "schools"
 end

--- a/test/controllers/manage/schools_controller_test.rb
+++ b/test/controllers/manage/schools_controller_test.rb
@@ -269,6 +269,7 @@ class Manage::SchoolsControllerTest < ActionController::TestCase
           patch :perform_merge, params: { id: @school, school: { id: "My Test School" } }
         end
       end
+      assert_equal @school.name, SchoolNameDuplicate.first.name
     end
 
     should "merge but not delete school if it contains questionnaires" do

--- a/test/factories/school_name_duplicate.rb
+++ b/test/factories/school_name_duplicate.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :school_name_duplicate do
+    sequence :id do |n|
+      n
+    end
+    sequence :name do |n|
+      "The University of Rails #{n}"
+    end
+  end
+end

--- a/test/fixtures/school_name_duplicates.yml
+++ b/test/fixtures/school_name_duplicates.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  school: one
+
+two:
+  name: MyString
+  school: two

--- a/test/models/questionnaire_test.rb
+++ b/test/models/questionnaire_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class QuestionnaireTest < ActiveSupport::TestCase
-
   should belong_to :school
 
   should strip_attribute :first_name
@@ -262,4 +261,16 @@ class QuestionnaireTest < ActiveSupport::TestCase
     end
   end
 
+  context "#consolidate_school_names" do
+    should "consolidate duplicate school names" do
+      school = create(:school, name: "My School", city: "Rochester", state: "NY")
+      bad_school = create(:school, name: "The My School")
+      create(:school_name_duplicate, name: "The My School", school: school)
+
+      questionnaire = create(:questionnaire, school: bad_school)
+      assert_equal "My School", questionnaire.school.name
+      assert_equal 1, school.reload.questionnaire_count
+      assert_equal 0, bad_school.reload.questionnaire_count
+    end
+  end
 end

--- a/test/models/school_name_duplicate_test.rb
+++ b/test/models/school_name_duplicate_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SchoolNameDuplicateTest < ActiveSupport::TestCase
+  should belong_to :school
+  should validate_uniqueness_of :name
+  should strip_attribute :name
+end


### PR DESCRIPTION
My MLH fails to eliminate duplicate school names - it's actually worse this year than it was last year.

Instead of doing a one-time merge of schools, perform a merge & merge future uses of the duplicate school.