### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The public facing site for Brick Hack.
 
 Install ruby, mysql, and other required development environment tools.
 ```bash
-$ brew install rbenv ruby-build rbenv-readline rbenv-gem-rehash rbenv-default-gems rbenv-binstubs
+$ brew install rbenv ruby-build rbenv-gem-rehash rbenv-default-gems rbenv-binstubs
 $ brew install redis
 $ brew install mysql
 ```


### PR DESCRIPTION
According to (https://github.com/tpope/rbenv-readline) the functionality of 'rbenv-readline' has been built into ruby-build which is already being installed. So remove it from the brew install for environment setup