### PR TITLE
Remove unused rbenv plugins from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The public facing site for Brick Hack.
 
 Install ruby, mysql, and other required development environment tools.
 ```bash
-$ brew install rbenv ruby-build rbenv-default-gems rbenv-binstubs
+$ brew install rbenv ruby-build rbenv-binstubs
 $ brew install redis
 $ brew install mysql
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The public facing site for Brick Hack.
 
 Install ruby, mysql, and other required development environment tools.
 ```bash
-$ brew install rbenv ruby-build rbenv-gem-rehash rbenv-default-gems rbenv-binstubs
+$ brew install rbenv ruby-build rbenv-default-gems rbenv-binstubs
 $ brew install redis
 $ brew install mysql
 ```


### PR DESCRIPTION
* rbenv-gem-rehash was merged into rbenv
* rbenv-default-gems is a development aid and configuration isn't discussed in our readme