### PR TITLE
Restore Blazer support

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -1,0 +1,56 @@
+# see https://github.com/ankane/blazer for more info
+
+data_sources:
+  main:
+    url: <%= ENV["BLAZER_DATABASE_URL"] %>
+
+    # statement timeout, in seconds
+    # none by default
+    # timeout: 15
+
+    # caching settings
+    # can greatly improve speed
+    # off by default
+    # cache:
+    #   mode: slow # or all
+    #   expires_in: 60 # min
+    #   slow_threshold: 15 # sec, only used in slow mode
+
+    # wrap queries in a transaction for safety
+    # not necessary if you use a read-only user
+    # true by default
+    # use_transaction: false
+
+    smart_variables:
+      # zone_id: "SELECT id, name FROM zones ORDER BY name ASC"
+      # period: ["day", "week", "month"]
+      # status: {0: "Active", 1: "Archived"}
+
+    linked_columns:
+      # user_id: "/admin/users/{value}"
+
+    smart_columns:
+      # user_id: "SELECT id, name FROM users WHERE id IN {value}"
+
+# create audits
+audit: true
+
+# change the time zone
+# time_zone: "Pacific Time (US & Canada)"
+
+# class name of the user model
+# user_class: User
+
+# method name for the user model
+# user_name: name
+
+# optional auth method to use as a before_action (default: nil)
+# before_action: :authenticate!
+
+# email to send checks from
+# from_email: blazer@example.org
+
+check_schedules:
+  - "1 day"
+  - "1 hour"
+  - "5 minutes"


### PR DESCRIPTION
When we moved to a Rails engine, Blazer's config file was moved as well. However, Blazer doesn't check engine directories for the config file - only the root one. To fix, we just copy the Blazer config to this repo.

Long-term solution may be different but this currently blocks us from running queries.