### PR TITLE
Use shared rubocop & resolve existing offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ AllCops:
 Bundler/OrderedGems:
   Enabled: false
 
-Documentation:
-  Enabled: false
-
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
@@ -17,10 +14,15 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/BlockLength:
-  Enabled: false
+  Exclude:
+    - test/**/*
+    - config/routes.rb
 
 Metrics/ClassLength:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 7
 
 Metrics/LineLength:
   Enabled: false
@@ -31,7 +33,7 @@ Metrics/MethodLength:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/CyclomaticComplexity:
+Style/Documentation:
   Enabled: false
 
 Style/StringLiterals:
@@ -43,13 +45,7 @@ Style/EmptyMethod:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/NumericLiterals:
-  Enabled: false
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Style/SpaceInsideBrackets:
+Style/SymbolArray:
   Enabled: false
 
 Style/WordArray:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# rubocop:disable BlockLength
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -42,7 +43,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  # config.action_cable.allowed_request_origins = ['http://example.com', /http:\/\/example.*/]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -52,7 +53,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w(manage.css home.css vendor/*.js vendor/*.css mailer.css)
+Rails.application.config.assets.precompile += %w[manage.css home.css vendor/*.js vendor/*.css mailer.css]

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
-%w(
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/test/controllers/mailer_test.rb
+++ b/test/controllers/mailer_test.rb
@@ -101,7 +101,7 @@ class MailerTest < ActionMailer::TestCase
 
       assert_equal ["test@example.com"],     email.to
       assert_equal "Incomplete Application", email.subject
-      assert_match /brickhack.io\/apply/,    email.encoded
+      assert_match %r{brickhack.io\/apply},  email.encoded
     end
   end
 
@@ -114,9 +114,9 @@ class MailerTest < ActionMailer::TestCase
     should "deliver invite email" do
       email = Mailer.slack_invite_email(@questionnaire.id).deliver_now
 
-      assert_equal ["test@example.com"], email.to
-      assert_equal "Slack Invite!", email.subject
-      assert_match /slack.com\/shared_invite/, email.encoded
+      assert_equal ["test@example.com"],         email.to
+      assert_equal "Slack Invite!",              email.subject
+      assert_match %r{slack.com\/shared_invite}, email.encoded
     end
   end
 
@@ -131,9 +131,9 @@ class MailerTest < ActionMailer::TestCase
     should "deliver update email" do
       email = Mailer.bus_list_update_email(@questionnaire.id).deliver_now
 
-      assert_equal ["test@example.com"], email.to
-      assert_equal "Bus Update", email.subject
-      assert_match /brickhack.io\/rsvp/, email.encoded
+      assert_equal ["test@example.com"],   email.to
+      assert_equal "Bus Update",           email.subject
+      assert_match %r{brickhack.io\/rsvp}, email.encoded
     end
   end
 end


### PR DESCRIPTION
Updates Rubocop to the most recent config format + brings us down to **0** offenses!

Only disabled the lints that really weren't needed - rubocop had sane defaults for everything else.

Should result in a lot less complaints from Hound, though still have to tweak HAML, SASS, and JS lint configs