### PR TITLE
Ignore db/schema.rb from codeclimate analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,3 +20,4 @@ exclude_paths:
 - public/**/*
 - test/**/*
 - "**/vendor/**/*"
+- db/schema.rb


### PR DESCRIPTION
`db/schema.rb` is generated & maintained by Rails, so Code Climate shouldn't be concerned with it