### PR TITLE
Disable Rollbar in rake tasks

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -7,12 +7,11 @@ Rollbar.configure do |config|
   config.environment = ENV['ROLLBAR_ENV']
 
   # Rollbar is only enabled in 'production' outside of rake tasks
+  # Note: 'rake rollbar:test' will not properly test the setup since
+  #       Rollbar is now disabled in rake tasks.
   if !Rails.env.production? || /rake/ =~ File.split($PROGRAM_NAME).last
     config.enabled = false
   end
-
-  # Note: 'rake rollbar:test' will not properly test the setup since
-  #       Rollbar is now disabled in rake tasks.
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -6,8 +6,13 @@ Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
   config.environment = ENV['ROLLBAR_ENV']
 
-  # Here we'll disable Rollbar when not in 'production':
-  config.enabled = false unless Rails.env.production?
+  # Rollbar is only enabled in 'production' outside of rake tasks
+  if !Rails.env.production? || /rake/ =~ File.split($PROGRAM_NAME).last
+    config.enabled = false
+  end
+
+  # Note: 'rake rollbar:test' will not properly test the setup since
+  #       Rollbar is now disabled in rake tasks.
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,


### PR DESCRIPTION
See issue: https://github.com/codeRIT/brickhack.io/issues/212

Rollbar is now disabled in rake tasks, regardless of environment.

Important note:
`rake rollbar:test` will not longer verify the Rollbar setup, as Rollbar is disabled in rake tasks!