### PR TITLE
Upgrade MySQL container to 5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: mysql:5.6.22
+    image: mysql:5.7
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 


### PR DESCRIPTION
Includes timezone info by default (required for Chartkick)