### PR TITLE
Save MySQL Docker db data between sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   db:
     image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
@@ -36,3 +38,4 @@ services:
 
 volumes:
   bundle_cache:
+  db_data:


### PR DESCRIPTION
Adds a docker-compose volume for `/var/lib/mysql`, ensuring database state isn't lost when containers are discarded.

As noted on https://hub.docker.com/_/mysql/ and https://docs.docker.com/compose/wordpress/#define-the-project