### PR TITLE
Replace @codeRIT.org emails with @brickhack.io

### DIFF
--- a/app/views/home/apilist.html.haml
+++ b/app/views/home/apilist.html.haml
@@ -34,7 +34,7 @@
         %h4 Contact
         %p
           Questions?
-          = link_to 'Contact us', 'mailto:hello@codeRIT.org'
+          = link_to 'Contact us', 'mailto:hello@brickhack.io'
         %p
           Found a bug?
           = link_to '<span class="fa fa-github fa-fw"></span> GitHub'.html_safe, 'https://github.com/codeRIT/brickhack.io/issues/new'

--- a/app/views/home/comingsoon.html.haml
+++ b/app/views/home/comingsoon.html.haml
@@ -83,10 +83,10 @@
 /      MLH has a great list of related questions over at <a href="https://mlh.io/faq" class="orange">mlh.io/faq</a>.
 /
 /    %h2 Are busses being provided?
-/    %h3 Busses will be provided to a specific number of schools, based on interest. If you're interested in getting a bus to your school, reach out to <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a>!
+/    %h3 Busses will be provided to a specific number of schools, based on interest. If you're interested in getting a bus to your school, reach out to <a href="mailto:travel@brickhack.io">travel@brickhack.io</a>!
 
 /    %h2 My question isn't answered here?
-/    %h3 Fret not! Feel free to reach out to us on <a href="https://twitter.com/brickhackrit" class="orange">Twitter</a>, <a href="https://www.facebook.com/brickhackrit" class="orange">Facebook</a>, or <a href="mailto:hello@codeRIT.org" class="orange">email</a>.
+/    %h3 Fret not! Feel free to reach out to us on <a href="https://twitter.com/brickhackrit" class="orange">Twitter</a>, <a href="https://www.facebook.com/brickhackrit" class="orange">Facebook</a>, or <a href="mailto:hello@brickhack.io" class="orange">email</a>.
 
 /#sponsors.home-section
 /  .blue-fill

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -33,7 +33,7 @@
     - if Rails.configuration.hackathon['event_is_over']
       = link_to "https://brickhack3.devpost.com/submissions/" do
         .button.button-outline SUBMISSIONS
-      = link_to URI.escape("mailto:hello@codeRIT.org?subject=BrickHack Organizer Interest&body=Hey there! I'm interested in helping organize BrickHack. How can I help?") do
+      = link_to URI.escape("mailto:hello@brickhack.io?subject=BrickHack Organizer Interest&body=Hey there! I'm interested in helping organize BrickHack. How can I help?") do
         .button.button-outline HELP ORGANIZE
     - else
       %br
@@ -111,7 +111,7 @@
 
       .column
         %h2 How am I supposed to get there?
-        %p If you live in the Rochester, NY area, you’re good to go. If not, we still welcome you! Some schools will have a bus provided; see below. Unfortunately we are unable to provide travel reimbursements. If you have any questions, contact <a href="mailto:travel@coderit.org">travel@codeRIT.org</a>.
+        %p If you live in the Rochester, NY area, you’re good to go. If not, we still welcome you! Some schools will have a bus provided; see below. Unfortunately we are unable to provide travel reimbursements. If you have any questions, contact <a href="mailto:travel@brickhack.io">travel@brickhack.io</a>.
 
       .column
         %h2 What should I bring?
@@ -165,7 +165,7 @@
 
       .column
         %h2 My question isn't answered here?
-        %p Fret not! Feel free to reach out to us on <a href="https://twitter.com/brickhackrit">Twitter</a>, <a href="https://www.facebook.com/brickhackrit">Facebook</a>, or <a href="mailto:hello@coderit.org">email</a>.
+        %p Fret not! Feel free to reach out to us on <a href="https://twitter.com/brickhackrit">Twitter</a>, <a href="https://www.facebook.com/brickhackrit">Facebook</a>, or <a href="mailto:hello@brickhack.io">email</a>.
 
 .white-section.diagonal#sponsors
   .home-content
@@ -208,7 +208,7 @@
         %h4 Contact
         %p
           Questions?
-          = link_to 'Contact us', 'mailto:hello@codeRIT.org'
+          = link_to 'Contact us', 'mailto:hello@brickhack.io'
         %p
           Found a bug?
           = link_to '<span class="fa fa-github fa-fw"></span> GitHub'.html_safe, 'https://github.com/codeRIT/brickhack.io/issues/new'

--- a/app/views/mailer/_getting_there.html.erb
+++ b/app/views/mailer/_getting_there.html.erb
@@ -1,6 +1,6 @@
 <!-- Waiting for bus info <h3>Getting There - Busses</h3>
 <p>Buses are being provided to Buffalo, Binghamton, Cornell, and Albany. If you are eligible, you will be given an option to sign up on the <a href="https://brickhack.io/rsvp">RSVP form</a>. <strong>You must RSVP and sign up for the bus to guarantee a seat!</strong></p>
-<p>If you live near these areas but don't see the bus sign-up option, please email <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a>.</p>-->
+<p>If you live near these areas but don't see the bus sign-up option, please email <a href="mailto:travel@brickhack.io">travel@brickhack.io</a>.</p>-->
 <h3>Getting There - Driving</h3>
 <p>If there isn't a bus available for your school, don't fret! We encourage you to carpool with others from your school.</p>
 <p><strong>A car pool list</strong> is available at the below link. If you're driving and would be open to taking a few more attendees with you, please list yourself!</p>

--- a/app/views/mailer/_questions.html.erb
+++ b/app/views/mailer/_questions.html.erb
@@ -1,2 +1,2 @@
 <h3>Questions?</h3>
-<p>If you have any questions, please check out our <a href="https://brickhack.io/#faq" target="_blank">FAQ</a>. You can also email <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a> with travel-related questions, or <a href="mailto:hello@codeRIT.org">hello@codeRIT.org</a> with general questions.</p>
+<p>If you have any questions, please check out our <a href="https://brickhack.io/#faq" target="_blank">FAQ</a>. You can also email <a href="mailto:travel@brickhack.io">travel@brickhack.io</a> with travel-related questions, or <a href="mailto:hello@brickhack.io">hello@brickhack.io</a> with general questions.</p>

--- a/app/views/mailer/bus_captain_confirmation_email.html.erb
+++ b/app/views/mailer/bus_captain_confirmation_email.html.erb
@@ -9,4 +9,4 @@
 </p>
 <p>This will be the central source of truth for passengers &amp; bus information, in addition to anything you hear from our travel director.</p>
 <p>This also means your <strong>name, email, and phone number</strong> are visible to everyone riding the bus. This information is taken straight from your BrickHack application, so please make sure it is up to date! You can check this at <a href="https://brickhack.io/apply">https://brickhack.io/apply</a></p>
-<p>Again, thank you so much for being a bus captain! If you have any questions at all, feel free to reach out to <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a>. We can't wait to see you at BrickHack!</p>
+<p>Again, thank you so much for being a bus captain! If you have any questions at all, feel free to reach out to <a href="mailto:travel@brickhack.io">travel@brickhack.io</a>. We can't wait to see you at BrickHack!</p>

--- a/config/hackathon.yml
+++ b/config/hackathon.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   name: BrickHack
   logo_asset: brickhack.png
   agreement_pdf_asset: BrickHack_ReleaseAgreement.pdf
-  email_from: '"BrickHack" <hello@codeRIT.org>'
+  email_from: '"BrickHack" <hello@brickhack.io>'
   default_page_title: BrickHack 4 - Jan 27-28, 2018
 
   disclaimer: |


### PR DESCRIPTION
Fixes #538 

Still requires an update to bus captain notes, which will come with the next hackathon_manager gem update.