### PR TITLE
Restore default Travis build dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
-dist: precise # Temp fix: https://github.com/travis-ci/travis-ci/issues/8331
 cache: bundler
 sudo: false
 bundler_args: --path vendor --local --without development
 env:
   - DATABASE_URL="mysql2://travis@localhost/myapp_test"
 before_script:
-  - mysql -e 'create database myapp_test;'
+  - mysql -u root -e "CREATE DATABASE myapp_test;"
+  - mysql -u root -e "GRANT ALL PRIVILEGES ON myapp_test.* TO 'travis'@'%';";
   - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
   - echo -e "Host csh-cloud.oweb.co\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 script:


### PR DESCRIPTION
Previously had to lock our Travis distribution to "precise" due to a change with how MySQL behaves  (https://github.com/travis-ci/travis-ci/issues/8331). However, there's a better solution that just involves granting all privileges to the travis MySQL user.

Been testing this with the WiCHacks repo and it's worked fine so far.