### PR TITLE
Restore better_errors support within Docker

### DIFF
--- a/config/initializers/better_errors.rb
+++ b/config/initializers/better_errors.rb
@@ -1,0 +1,6 @@
+if defined? BetterErrors
+  # Private subnets defined by RFC1918 as stated in https://docs.docker.com/v1.5/articles/networking/
+  BetterErrors::Middleware.allow_ip! '10.0.0.0/8'
+  BetterErrors::Middleware.allow_ip! '172.16.0.0/12'
+  BetterErrors::Middleware.allow_ip! '192.168.0.0/16'
+end


### PR DESCRIPTION
The [better_errors](https://github.com/charliesome/better_errors/) gem stopped working ever since we started using Docker. This appears to be due to BetterErrors' IP whitelisting, where the default is to only allow localhost access (since this opens up a full-fledged web shell, which is dangerous if your computer's IP is publicly available). Since the Rails app runs inside a Docker container now, "localhost" is actually external of 127.0.0.1.

This fix opens up better_errors to all local/private subnets - enough to give your computer access to better_errors, but not so far that the whole internet can access it. This *does* enable access for other people on your local network, but I think that's a safe bargain. 

Source: https://github.com/charliesome/better_errors/issues/349#issuecomment-263832105