### PR TITLE
Resolve issue with Rails not starting due to PID file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,12 @@ services:
 
   web:
     build: .
-    command: rails server --port 3000 --binding 0.0.0.0
+    command:
+      - rails
+      - server
+      - --port=3000
+      - --binding=0.0.0.0
+      - --pid=/tmp/rails-server.pid
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Rails stores the active server's PID at `tmp/pids/server.pid` by default. This prevents multiple Rails servers from being run at once.

However, when run with Docker, this PID file isn't always cleaned up. As a result, this prevents the server from starting in the container, even though there isn't actually an active server.

To fix this, the PID file path is changed to a container-temporary directory (`/tmp`), instead of a shared volume directory (`/app/tmp`). With this, the PID file is guaranteed to not carry over into future containers, resolving the issue.