### PR TITLE
Improve "sign up" message phrasing

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,9 +34,9 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up: "Welcome! Your account has been created. Please complete your application below!"
+      signed_up_but_inactive: "Your account has been created. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "Your account has been created. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."


### PR DESCRIPTION
Saying "you have signed up successfully" is misleading, as the user still has to complete their questionnaire.