### PR TITLE
Remove static data initializer

### DIFF
--- a/config/initializers/static_data.rb
+++ b/config/initializers/static_data.rb
@@ -1,7 +1,0 @@
-static_data = {}
-Dir["#{Rails.root}/config/data/**/*.yml"].each do |file|
-  basename = File.basename(file, ".yml")
-  static_data[basename] = YAML.load_file(file)
-end
-
-STATIC_DATA = static_data.freeze


### PR DESCRIPTION
Not used anymore, plus was hard to work with in the first place due to no auto-reloading of the config files.

Closes #559