### PR TITLE
Improve mobile display

### DIFF
--- a/app/assets/stylesheets/home.sass
+++ b/app/assets/stylesheets/home.sass
@@ -160,7 +160,7 @@ nav
   width: 100%
   .desktop &
     display: flex
-    flex-direction: row
+    flex-flow: row wrap
     align-items: baseline
   .mobile &
     text-align: center
@@ -615,7 +615,7 @@ p
   nav.desktop
 
     .nav-links
-      width: auto
+      width: 100%
       a
         margin: 0 2%
 

--- a/app/views/home/_schedule.html.haml
+++ b/app/views/home/_schedule.html.haml
@@ -1,6 +1,6 @@
 - event_schedule = Schedule.new("1Ssak3FU6V0sJP3uPZCCsk8RITu6wW6lvaA6wlSGSOuI", 0)
 
-.page.white-section.diagonal#schedule
+.page.white-section#schedule
   .home-content
     %h1
       .orange


### PR DESCRIPTION
* The schedule from last year included a diagonal shape for each section, which causes overflow on mobile - can just be removed.
* The nav links could overflow the screen width on small screens