### PR TITLE
Add help text for expanding schedule info

### DIFF
--- a/app/assets/stylesheets/home.sass
+++ b/app/assets/stylesheets/home.sass
@@ -228,6 +228,9 @@ p
 .white
   color: $white
 
+.grey
+  color: $grey
+
 .title
   color: $black
   font-size: 48px

--- a/app/views/home/_schedule.html.haml
+++ b/app/views/home/_schedule.html.haml
@@ -31,3 +31,6 @@
                     .schedule__location= row[2]
                   - if row[3] && row[3] != ':static'
                     .schedule__desc= row[3].html_safe
+    %p.grey
+      %span.fa.fa-mouse-pointer.icon-space-r.icon-space-l
+      Click on any event for more details


### PR DESCRIPTION
Thoughts? (the text at the bottom)

<img width="1320" alt="screenshot 2018-01-23 16 33 06" src="https://user-images.githubusercontent.com/1441807/35301988-199a1fce-005b-11e8-9826-1f426f25cd44.png">
