### PR TITLE
Apply 2019 design to account pages

### DIFF
--- a/app/assets/stylesheets/header-overrides.sass
+++ b/app/assets/stylesheets/header-overrides.sass
@@ -1,35 +1,26 @@
 .header
-  border-bottom: 1px solid #666 !important
-  height: 60px !important
-
-.header__wrapper
-  max-width: 100% !important
-  padding-right: 10px !important
-
-.header-logo--with-nav
-  display: flex
-  flex-flow: row nowrap
-  margin-left: 10%
-  @media (max-width: 1000px)
-    margin-left: 15px
-  @media (max-width: 600px)
-    margin-left: 0
+  $color-stop-1: #0f3f5d
+  $color-stop-2: #26325f
+  $color-stop-3: mix(#2A245F, $color-stop-2, 40%)
+  background-color: #402761
+  background: linear-gradient($color-stop-1, mix($color-stop-1, $color-stop-2), $color-stop-3) !important
+  height: auto !important
+  flex-flow: column nowrap !important
+  align-items: center
+  position: relative
+  overflow: hidden
 
 .header-logo
+  display: flex
   align-items: center
 
+  @media (max-width: 400px)
+    margin-left: -10px
+
 .header-logo__image
-  height: 45px !important
-  display: flex
+  height: 60px !important
+  margin: 7px 0 0 !important
 
-.header-nav__links
-  margin-left: 20px
-  margin-right: -20px
-  @media (max-width: 600px)
-    display: none !important
-
-.header-nav__link
-  color: #4d4d4d
-  font-weight: 600
-  padding: 0 20px
-  text-transform: uppercase
+.header__wrapper
+  position: relative
+  z-index: 1

--- a/app/assets/stylesheets/page-banner.sass
+++ b/app/assets/stylesheets/page-banner.sass
@@ -1,25 +1,23 @@
 .page-banner
-  background: asset-url('accounts/account_asset_outline.png') center top
   display: flex
   width: 100%
-  height: 265px
+  height: 230px
   justify-content: center
   margin-bottom: 5px
+  z-index: 1
 
 .page-banner__inner
   font-size: 45px
-  color: #000
+  color: #fff
   font-weight: 700
   display: flex
   align-items: center
 
-  // Fit within open space
-  margin-top: 87px
   width: 520px
   margin-left: -220px
   padding-left: 39px
-  padding-bottom: 40px
   line-height: 1.3
+  margin-top: -40px
 
 .page-banner__text
   overflow: hidden
@@ -48,3 +46,28 @@
 
   .page-banner__inner
     padding-left: 30px
+
+.page-banner__left-background
+  background: asset-url('home/about-background-bricks.svg') no-repeat center center
+  width: 600px
+  height: 600px
+  position: absolute
+  opacity: 0.3
+  background-size: 520px
+  margin-left: -320px
+  margin-top: 80px
+
+  @media (max-width: 480px)
+    background-image: asset-url('home/about-background-bricks-double.svg')
+    height: 1200px
+    margin-top: 40px
+
+.page-banner__right-background
+  background: asset-url('home/about-background-circuit.svg') no-repeat center center
+  width: 750px
+  height: 590px
+  position: absolute
+  opacity: 0.3
+  background-size: 690px
+  margin-top: 90px
+  margin-left: 230px

--- a/app/views/layouts/hackathon_manager/_header.html.haml
+++ b/app/views/layouts/hackathon_manager/_header.html.haml
@@ -1,14 +1,9 @@
 .header
   .header__wrapper.account-nav__wrapper
     - if Rails.configuration.hackathon['logo_asset']
-      .header-logo.header-logo--with-nav
+      .header-logo
         = link_to root_path do
           = image_tag Rails.configuration.hackathon['logo_asset'], id: 'logo', alt: "#{Rails.configuration.hackathon['name']} logo", title: Rails.configuration.hackathon['name'], class: 'header-logo__image'
-        .header-nav.header-nav__links
-          = link_to "About", "/#about", class: 'header-nav__link'
-          = link_to "Travel", "/#travel", class: 'header-nav__link'
-          = link_to "FAQs", "/#faq", class: 'header-nav__link'
-          = link_to "Sponsors", "/#sponsor", class: 'header-nav__link'
     - else
       .header-nav
         = btn_link_to "Home", root_path
@@ -18,13 +13,15 @@
           = btn_link_to "Manage", manage_root_path
         = btn_link_to "Sign Out", destroy_user_session_path, method: :delete
 
-- first_name = current_user&.questionnaire&.first_name.presence
-- page_title = content_for(:page_title)
-- if (first_name || page_title) && controller.class.parent != Manage
-  .page-banner
-    .page-banner__inner
-      %span.page-banner__text
-        - if first_name
-          Hello, #{first_name}
-        - else
-          = page_title
+  - first_name = current_user&.questionnaire&.first_name.presence
+  - page_title = content_for(:page_title)
+  - if (first_name || page_title) && controller.class.parent != Manage
+    .page-banner
+      .page-banner__inner
+        %span.page-banner__text
+          - if first_name
+            Hello, #{first_name}
+          - else
+            = page_title
+    .page-banner__left-background
+    .page-banner__right-background


### PR DESCRIPTION
Roughly copied based on the homepage design

RSVP & Application pages:

<img width="1920" alt="screenshot 2018-11-01 19 43 51" src="https://user-images.githubusercontent.com/1441807/47891026-bf963200-de0e-11e8-8917-df5c965cf7c5.png">

<img width="1920" alt="screenshot 2018-11-01 19 43 57" src="https://user-images.githubusercontent.com/1441807/47891027-bf963200-de0e-11e8-8919-e1d7e09cbcae.png">
