### PR TITLE
Loosen some haml-lint rules

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -9,12 +9,14 @@ linters:
   ClassAttributeWithStaticValue:
     enabled: true
 
+  # .class#id vs #id.class
   ClassesBeforeIds:
     enabled: false
 
   ConsecutiveComments:
     enabled: true
 
+  # use :ruby block instead of multiple "-" lines
   ConsecutiveSilentScripts:
     enabled: true
     max_consecutive: 5
@@ -25,6 +27,7 @@ linters:
   HtmlAttributes:
     enabled: true
 
+  # E.g. using lispCase instead of snake_case
   IdNames:
     enabled: false
 
@@ -58,6 +61,7 @@ linters:
   SpaceBeforeScript:
     enabled: true
 
+  # Space after/before curly brackets
   SpaceInsideHashAttributes:
     enabled: false
 

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,20 +10,23 @@ linters:
     enabled: true
 
   ClassesBeforeIds:
-    enabled: true
+    enabled: false
 
   ConsecutiveComments:
     enabled: true
 
   ConsecutiveSilentScripts:
     enabled: true
-    max_consecutive: 2
+    max_consecutive: 5
 
   EmptyScript:
     enabled: true
 
   HtmlAttributes:
     enabled: true
+
+  IdNames:
+    enabled: false
 
   ImplicitDiv:
     enabled: true
@@ -56,8 +59,7 @@ linters:
     enabled: true
 
   SpaceInsideHashAttributes:
-    enabled: true
-    style: space
+    enabled: false
 
   TagName:
     enabled: true

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -31,23 +31,24 @@
 %a#mlh-trust-badge{:href => "https://mlh.io/seasons/na-2019/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2019-season&utm_content=gray", :style => "display:block;max-width:100px;min-width:60px;position:fixed;right:30px;top:0;width:8%;z-index:10000", :target => "_blank"}
   %img{:alt => "Major League Hacking 2019 Hackathon Season", :src => "https://s3.amazonaws.com/logged-assets/trust-badge/2019/mlh-trust-badge-2019-gray.svg", :style => "width:100%"}/
 
--# mobile nav
--# %nav.mobile
--#   %i.fa.fa-bars.mob-nav-header#hamburger-menu
--#   %h2.mob-nav-header{ style: 'font-size: 24px; text-align: left; color: white; padding:0; margin: 0; position: relative; top: -5px; font-weight: 300' } BrickHack
+-#
+  mobile nav
+  %nav.mobile
+    %i.fa.fa-bars.mob-nav-header#hamburger-menu
+    %h2.mob-nav-header{ style: 'font-size: 24px; text-align: left; color: white; padding:0; margin: 0; position: relative; top: -5px; font-weight: 300' } BrickHack
 
--#   #mobile-nav
--#     .nav-links
--#       %a.active{ href: '#' } BrickHack
+    #mobile-nav
+      .nav-links
+        %a.active{ href: '#' } BrickHack
 
--#       - pages.each do |page|
--#         %a{ href: "##{page.downcase}" }= page
+        - pages.each do |page|
+          %a{ href: "##{page.downcase}" }= page
 
--#       - if current_user
--#         - if current_user.admin
--#           = btn_link_to 'Manage', manage_dashboard_index_path
--#         - else
--#           = btn_link_to 'My Account', questionnaires_path, class: 'mobile'
--#       - else
--#         - text = Rails.configuration.hackathon['registration_is_open'] ? 'Sign Up / Sign In' : 'Sign In'
--#         = link_to text, new_user_registration_path, class: 'mobile'
+        - if current_user
+          - if current_user.admin
+            = btn_link_to 'Manage', manage_dashboard_index_path
+          - else
+            = btn_link_to 'My Account', questionnaires_path, class: 'mobile'
+        - else
+          - text = Rails.configuration.hackathon['registration_is_open'] ? 'Sign Up / Sign In' : 'Sign In'
+          = link_to text, new_user_registration_path, class: 'mobile'

--- a/app/views/pages/_faq.html.haml
+++ b/app/views/pages/_faq.html.haml
@@ -1,17 +1,20 @@
-- @involved_link = 'mailto:hello@brickhack.io?subject=I&#39;d%20like%20to%20get%20involved!'
+:ruby
+  involved_link = 'mailto:hello@brickhack.io?subject=I&#39;d%20like%20to%20get%20involved!'
 
-- @faq_content = {'Do I need a team to join?' => 'While teams are often recommended and sometimes more fun, they\'re not required. We will be hosting a teambuilding event shortly after kickoff, but feel free to invite your friends! Teams are a max of 4 people. Each person must register individually.',
-  'What should I bring?' => 'Bring yourself, a photo ID, clothes, toiletries, a sleeping bag/blanket, your hacker setup, and maybe an idea or two.',
-  'Who can participate in BrickHack?' => 'Anyone currently enrolled as a student can attend! If you don\'t fit that description, you\'re absolutely welcome to attend as a <a href='+@involved_link+'>mentor</a> or <a href='+@involved_link+'>volunteer</a>. All attendees must be 18 years or older.',
-  'Do RIT students need to apply?' => 'Yes, RIT students need to apply just like everyone else.',
-  'When will I know if I got in?' => 'Acceptance notifications will start being sent out January 16th on a rolling basis.',
-  'Should I bring my own bricks?' => 'We\'ve got you covered.',
-  'My question isn\'t answered here...' => 'Fret not! Feel free to reach out to us on <a href="https://twitter.com/brickhackrit">Twitter</a>, <a href="https://www.facebook.com/brickhackrit">Facebook</a>, or <a href="mailto:hello@brickhack.io">email</a>.'}
+  faq_content = {
+    "Do I need a team to join?" => "While teams are often recommended and sometimes more fun, they're not required. We will be hosting a teambuilding event shortly after kickoff, but feel free to invite your friends! Teams are a max of 4 people. Each person must register individually.",
+    "What should I bring?" => "Bring yourself, a photo ID, clothes, toiletries, a sleeping bag/blanket, your hacker setup, and maybe an idea or two.",
+    "Who can participate in BrickHack?" => "Anyone currently enrolled as a student can attend! If you don't fit that description, you're absolutely welcome to attend as a <a href=\"#{involved_link}\">mentor</a> or <a href=\"#{involved_link}\">volunteer</a>. All attendees must be 18 years or older.",
+    "Do RIT students need to apply?" => "Yes, RIT students need to apply just like everyone else.",
+    "When will I know if I got in?" => "Acceptance notifications will start being sent out January 16th on a rolling basis.",
+    "Should I bring my own bricks?" => "We've got you covered.",
+    "My question isn't answered here..." => "Fret not! Feel free to reach out to us on <a href=\"https://twitter.com/brickhackrit\">Twitter</a>, <a href=\"https://www.facebook.com/brickhackrit\">Facebook</a>, or <a href=\"mailto:hello@brickhack.io\">email</a>."
+  }
 
 .faq__items
-  - @faq_content.each do |question, answer|
+  - faq_content.each do |question, answer|
     .faq__item
-      - if question == 'My question isn\'t answered here...'
+      - if question == "My question isn't answered here..."
         %br
         %br
         %p.faq__question


### PR DESCRIPTION
Some of the default haml-lint rules are more stylistic than functional. Being an open-source student-run project, I don't think we need to enforce the stylistic ones as much.

Also cleaned up faq.html.haml and nav.html.haml for the existing warnings haml-lint was mentioning