### PR TITLE
Remove Sidekiq from local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,5 @@ bower.json
 # don't commit local env vars
 .env
 
-# Local lock for bundler in Docker
-.bundle-install-lock
-
 # Mac stuff
 *.DS_Store

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,8 +5,3 @@ services:
       - ../hackathon_manager:/hackathon_manager
     environment:
       - HACKATHON_MANAGER_DEV=1
-  sidekiq:
-    volumes:
-      - ../hackathon_manager:/hackathon_manager
-    environment:
-      - HACKATHON_MANAGER_DEV=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,18 +29,6 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
 
-  sidekiq:
-    build: .
-    command: sidekiq
-    depends_on:
-      - db
-      - redis
-    volumes:
-      - .:/app
-      - bundle_cache:/bundle
-    environment:
-      - REDIS_URL=redis://redis:6379
-
 volumes:
   bundle_cache:
   db_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
-# Ensure we don't have two containers simultaneously running "bundle install"
-until [ ! -f .bundle-install-lock ]; do
-  >&2 echo "Another container is running 'bundle install' - waiting"
-  sleep 5
-done
-
-touch .bundle-install-lock
 # Ensure all gems installed. Add binstubs to bin which has been added to PATH in Dockerfile.
 bundle check || bundle install --binstubs="$BUNDLE_BIN"
-rm -f .bundle-install-lock
 
 # Clean up a potential leftover Rails pid file
 rm -f /tmp/rails-server.pid


### PR DESCRIPTION
Sidekiq won't be necessary with the split from brickhack.io and apply.brickhack.io, since we won't have background jobs being used anymore.

As a step one, remove it from the local development docker setup.

This also removes the need to worry about a `.bundle-install-lock` file