### PR TITLE
Fix mobile margin for input field

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -239,10 +239,7 @@ lines of text may be wider than they appear
 .mailchimp-container {
   height: 40px;
   width: 375px;
-  margin: auto;
-
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin: 20px auto;
 
   border-style: solid;
   border-width: 1px;
@@ -252,7 +249,8 @@ lines of text may be wider than they appear
   @include mobile {
     width: 80vw;
 
-    margin-top: 1vh;
+    // On mobile, only enforce top margin
+    margin: 1vh auto auto auto;
 
     height: 12vw;
     border-radius: 6vw;


### PR DESCRIPTION
On mobile sizes, only top margin is enforced on the input field.
On desktop, it's 20px top/bottom, auto around.

Before
<img src="https://user-images.githubusercontent.com/2782749/90557354-5826af00-e168-11ea-824d-72226f652e97.png" width="300px" />

After
<img src="https://user-images.githubusercontent.com/2782749/90557367-5eb52680-e168-11ea-9cfc-ca885d50ced4.png" width="300px" />
