### PR TITLE
Content is now (visually) vertically centered on tablet, fixed extra mobile whitespace bug

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -185,7 +185,7 @@ html, body, #root, #app, .full-height {
 	@include tablet {
 		max-width: 100%;
 		flex-direction: column;
-		margin: 0px;
+		margin: auto;
 	}
 }
 
@@ -195,6 +195,10 @@ html, body, #root, #app, .full-height {
 .left-half {
 	@extend .right-half;
 	margin-bottom: 2.5vh;
+
+	@include tablet {
+		margin-bottom: 20vh;
+	}
 }
 
 .hero-img {

--- a/src/index.scss
+++ b/src/index.scss
@@ -14,6 +14,9 @@ $mobile-width: 750px;
 @mixin desktop {
 	@media(min-width: #{$desktop-width}) { @content; }
 }
+@mixin tablet-only {
+	@media(max-width: #{$desktop-width}) { @media(min-width: #{$mobile-width}) {@content; } }
+}
 /*tablet mixin also applies to mobile*/
 @mixin tablet {
 	@media(max-width: #{$desktop-width}) { @content; }
@@ -167,11 +170,13 @@ html, body, #root, #app, .full-height {
 }
 
 .section {
-	height: 100%;
 	display: flex;
 	flex-direction: column;
 	@include desktop {
-		min-height: 775px;
+		min-height: 750px;
+	}
+	@include tablet-only {
+		height: calc(100% - 74.5px);
 	}
 }
 
@@ -196,7 +201,7 @@ html, body, #root, #app, .full-height {
 	@extend .right-half;
 	margin-bottom: 2.5vh;
 
-	@include tablet {
+	@include tablet-only {
 		margin-bottom: 20vh;
 	}
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -204,7 +204,7 @@ html, body, #root, #app, .full-height {
 	margin-bottom: 2.5vh;
 
 	@include tablet {
-		margin-bottom: 20vh;
+		margin-bottom: 15vh;
 	}
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -167,9 +167,9 @@ html, body, #root, #app, .full-height {
 }
 
 .section {
+	height: 100%;
 	display: flex;
 	flex-direction: column;
-	height: 100%;
 	
 	@include desktop {
 		min-height: 750px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -14,9 +14,6 @@ $mobile-width: 750px;
 @mixin desktop {
 	@media(min-width: #{$desktop-width}) { @content; }
 }
-@mixin tablet-only {
-	@media(max-width: #{$desktop-width}) { @media(min-width: #{$mobile-width}) {@content; } }
-}
 /*tablet mixin also applies to mobile*/
 @mixin tablet {
 	@media(max-width: #{$desktop-width}) { @content; }
@@ -172,11 +169,16 @@ html, body, #root, #app, .full-height {
 .section {
 	display: flex;
 	flex-direction: column;
+	height: 100%;
+	
 	@include desktop {
 		min-height: 750px;
 	}
-	@include tablet-only {
+	@include tablet {
 		height: calc(100% - 74.5px);
+	}
+	@include mobile {
+		height: 0%;
 	}
 }
 
@@ -201,7 +203,7 @@ html, body, #root, #app, .full-height {
 	@extend .right-half;
 	margin-bottom: 2.5vh;
 
-	@include tablet-only {
+	@include tablet {
 		margin-bottom: 20vh;
 	}
 }


### PR DESCRIPTION
| Device | Before | After |
| :- | :-: | -: |
| iPad | ![image](https://user-images.githubusercontent.com/31863372/94328967-ff2b1180-ff84-11ea-8170-5b7037d07872.png) |![image](https://user-images.githubusercontent.com/31863372/94329009-5cbf5e00-ff85-11ea-8a3b-088c85dc1de3.png) | 
| iPad Pro| ![image](https://user-images.githubusercontent.com/31863372/94329038-909a8380-ff85-11ea-9917-6fafa64e87e3.png) |![image](https://user-images.githubusercontent.com/31863372/94329029-82e4fe00-ff85-11ea-9001-2a279c3d8f3d.png) |

resolves #963 