### PR TITLE
Move section padding to fix arrow bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
             </div>
         </div>
     </section>
-    <section id="hackathon">
-        <div class="carousel section-pad-top">
+    <section id="hackathon" class="section-pad-top">
+        <div class="carousel">
             <div class="slide">
                 <div class="wire"></div>
                 <div class="front-clip"></div>


### PR DESCRIPTION
Fixes #1031 ... again

Moved `section-pad-top` from carousel to `#hackathon` so the arrows can position directly in middle of carousel

| before | after |
|---|---|
![Screenshot_2020-12-18 BrickHack 7(2)](https://user-images.githubusercontent.com/2782749/102643855-e4a0a880-412d-11eb-8585-cd1ff34bb4dd.jpg)|![Screenshot_2020-12-18 BrickHack 7(1)](https://user-images.githubusercontent.com/2782749/102643852-e36f7b80-412d-11eb-86c7-1dbc4c8d8e93.jpg)
