### PR TITLE
Fix Discord link

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                 <p id="dates">FEB 20-21 | RIT DIGITAL HACKATHON</p>
                 <div id="action-buttons">
                     <a id="register" href="https://apply.brickhack.io/users/sign_up">REGISTER</a>
-                    <a id="discord" href="https://discord.gg/4xjWuSeP9Q">DISCORD</a>
+                    <a id="discord" href="https://discord.gg/rXapGXsYEK">DISCORD</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #1175 
Now links to #registration vs. linking to #directors (which would error out obvs)